### PR TITLE
Add support for non-Twitter output

### DIFF
--- a/anon.coffee
+++ b/anon.coffee
@@ -1,4 +1,3 @@
-Twit        = require 'twit'
 Netmask     = require('netmask').Netmask
 minimist    = require 'minimist'
 WikiChanges = require('wikichanges').WikiChanges
@@ -31,9 +30,14 @@ isIpInAnyRange = (ip, blocks) ->
       return true
   return false
 
+loadNotifier = (config) ->
+  notifier_class = require("./notifiers/#{config['notifier']}").notifier
+  return new notifier_class(config)
+  
 main = ->
   config = require(argv.config)
-  twitter = new Twit config unless argv['noop']
+  notifiers = (loadNotifier(c) for c in config['notifiers'])
+
   wikipedia = new WikiChanges(ircNickname: config.nick)
   wikipedia.listen (edit) ->
     # if we have an anonymous edit, then edit.user will be the ip address
@@ -44,9 +48,7 @@ main = ->
           status = edit.page + ' Wikipedia article edited anonymously by ' + name + ' ' + edit.url
           console.log status
           return if argv.noop
-          twitter.post 'statuses/update', status: status, (err, d, r) ->
-            if err
-              console.log err
+          notifier.notify(status) for notifier in notifiers
           return
 
 if require.main == module

--- a/config.json.template
+++ b/config.json.template
@@ -1,9 +1,14 @@
 {
   "nick": "yourIrcNickHere",
-  "consumer_key": "",
-  "consumer_secret": "",
-  "access_token": "",
-  "access_token_secret": "",
+  "notifiers": [
+    {
+      "notifier": "twitter",
+      "consumer_key": "",
+      "consumer_secret": "",
+      "access_token": "",
+      "access_token_secret": ""
+    }
+  ],
   "ranges": {
     "US House of Representatives": [
       ["143.231.0.0", "143.231.255.255"],
@@ -18,5 +23,3 @@
     ]
   }
 }
-
-

--- a/notifiers/console.coffee
+++ b/notifiers/console.coffee
@@ -1,0 +1,5 @@
+ConsoleNotifier = (config) ->
+  notify: (status) -> 
+    console.log config['prefix'] + ': ' + status
+  
+exports.notifier = ConsoleNotifier

--- a/notifiers/twitter.coffee
+++ b/notifiers/twitter.coffee
@@ -1,0 +1,13 @@
+Twit = require 'twit'
+
+TwitterNotifier = (config) ->
+  twitter = new Twit config unless argv['noop']
+
+  notify = (status) -> 
+    twitter.post 'statuses/update', status: status, (err, d, r) ->
+    if err
+      console.log err
+
+  return this
+  
+exports.notifier = TwitterNotifier


### PR DESCRIPTION
Make it simple to create pluggable output notifiers instead of locking into Twitter
