### PR TITLE
Austria Edits (config.json)

### DIFF
--- a/conf/austriaedits.json
+++ b/conf/austriaedits.json
@@ -1,0 +1,20 @@
+{
+  "ranges": {
+    "Bundesrechenzentrum": [
+      ["85.158.226.128", "85.158.226.159"]
+    ],
+    "Parlament": [
+      "161.110.0.0/16"
+    ],
+    "Bundesministerium für Inneres": [
+      "78.41.149.0/24"
+    ],
+    "Bundeskanzleramt": [
+      "78.41.144.0/24"
+    ],
+    "Statistik Austria": [
+      "193.170.0.0/15"
+    ],
+    
+  }
+}


### PR DESCRIPTION
Added IP ranges of
- federal computing center
- parliament 
- interior ministry
- federal chancellery
- statistical office

of the Republic of Austria.

(Most probably very incomplete.)
