### PR TITLE
Updates to get things running in Docker again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /opt/anon
 WORKDIR /opt/anon
 
 RUN  apt-get update \
- && apt-get install --yes build-essential libicu-dev \
+ && apt-get install --yes build-essential libicu-dev chromium libgconf-2-4 libatk1.0-0 libatk-bridge2.0-0 libgdk-pixbuf2.0-0 libgtk-3-0 libgbm-dev libnss3-dev libxss-dev \
  && npm install \
  && ln -s /opt/anon/anon.js /usr/bin/anon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:16
 
 COPY . /opt/anon
 WORKDIR /opt/anon
@@ -9,4 +9,3 @@ RUN  apt-get update \
  && ln -s /opt/anon/anon.js /usr/bin/anon
 
 CMD ["anon"]
-

--- a/anon.js
+++ b/anon.js
@@ -120,7 +120,8 @@ async function takeScreenshot(url) {
   const filename = Date.now() + '.png'
 
   const browser = await puppeteer.launch({
-    headless: true, 
+    args: ['--no-sandbox'],
+    headless: true,
     defaultViewport: {
       width: 1024,
       height: 768,


### PR DESCRIPTION
A couple updates to get things running again locally for gccaedits.

- Using an updated version of `npm`
- Added chromium and dependencies Docker containers
- Run puppeteer with `--no-sandbox` (it's a lazy hack to avoid errors like below)

```
Draft:Brampton Mortgage Wikipedia article edited anonymously from Shared Services Canada https://en.wikipedia.org/w/index.php?oldid=1128532486&rcid=1581842217                                                     
/opt/anon/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:193                                                                                                                                       
            reject(new Error([                                                                                                                                                                                     
                   ^                                                                                                                                                                                               
                                                                                                                                                                                                                   
Error: Failed to launch the browser process!                                                                                                                                                                       
[1220/165729.434964:ERROR:zygote_host_impl_linux.cc(90)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.                                                                      
                                                                                                                                                                                                                   
                                                                                                                                                                                                                   
TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md                                                                                                                          
                                                                                                                                                                                                                   
    at onClose (/opt/anon/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:193:20)                                                                                                                   
    at Interface.<anonymous> (/opt/anon/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:183:68)                                                                                                     
    at Interface.emit (node:events:525:35)                                                                                                                                                                         
    at Interface.close (node:readline:590:8)                                                                                                                                                                       
    at Socket.onend (node:readline:280:10)                                                                                                                                                                         
    at Socket.emit (node:events:525:35)                                                                                                                                                                            
    at endReadableNT (node:internal/streams/readable:1358:12)                                                                                                                                                      
    at processTicksAndRejections (node:internal/process/task_queues:83:21)      
```